### PR TITLE
Fixed typo in stop_watch_cell cellulose/logger_multicast_backend dependency.

### DIFF
--- a/stop_watch_cell/mix.exs
+++ b/stop_watch_cell/mix.exs
@@ -28,7 +28,7 @@ defmodule StopWatch.Mixfile do
     { :jrtp_bridge, github: "cellulose/jrtp_bridge" },
     { :ethernet, github: "cellulose/ethernet" },
     { :discovery, github: "cellulose/discovery" },
-    { :logger_multicast_backend, github: "cellulose/logger_muticast_backend"}
+    { :logger_multicast_backend, github: "cellulose/logger_multicast_backend"}
   ]
 
 end

--- a/stop_watch_cell/mix.lock
+++ b/stop_watch_cell/mix.lock
@@ -11,4 +11,5 @@
   "jrtp_bridge": {:git, "git://github.com/cellulose/jrtp_bridge.git", "89ce729c17a74ffe3daea1cd0356f12035bc0968", []},
   "jsx": {:git, "git://github.com/talentdeficit/jsx.git", "e50af6e109cb03bd26acf715cbc77de746507d1d", [ref: "v1.4.3"]},
   "leds": {:git, "git://github.com/cellulose/leds.git", "e7e7fc83c7282f41999a47bb4fea729c513a2934", []},
+  "logger_multicast_backend": {:git, "git://github.com/cellulose/logger_multicast_backend.git", "829a94cafd81d13a70fcca7b8f0d8006a7996e8b", []},
   "ranch": {:hex, :ranch, "1.0.0"}}


### PR DESCRIPTION
``` text
* Updating logger_multicast_backend (git://github.com/cellulose/logger_muticast_backend.git)
fatal: remote error: 
  Repository not found.
```
